### PR TITLE
Automapper Fix when using AutoMapper ProjectTo in LINQ query

### DIFF
--- a/src/EntityFrameworkMock.Shared/DbAsyncQueryProvider.cs
+++ b/src/EntityFrameworkMock.Shared/DbAsyncQueryProvider.cs
@@ -19,18 +19,13 @@ namespace EntityFrameworkMock
 
         public IQueryable CreateQuery(Expression expression)
         {
-            switch (expression)
-            {
-                case MethodCallExpression m:
-                {
-                    var resultType = m.Method.ReturnType;
-                    var genericElement = resultType.GetGenericArguments()[0];
-                    var queryType = typeof(DbAsyncEnumerable<>).MakeGenericType(genericElement);
-                    return (IQueryable)Activator.CreateInstance(queryType, expression);
-                }
-            }
+            if (!(expression is MethodCallExpression mExpression))
+                return new DbAsyncEnumerable<TEntity>(expression);
 
-            return new DbAsyncEnumerable<TEntity>(expression);
+            var resultType = mExpression.Method.ReturnType;
+            var genericElement = resultType.GetGenericArguments()[0];
+            var queryType = typeof(DbAsyncEnumerable<>).MakeGenericType(genericElement);
+            return (IQueryable)Activator.CreateInstance(queryType, expression);
         }
 
         public IQueryable<TElement> CreateQuery<TElement>(Expression expression) => new DbAsyncEnumerable<TElement>(expression);

--- a/tests/EntityFrameworkMock.Moq.Tests/EntityFrameworkMock.Moq.Tests.csproj
+++ b/tests/EntityFrameworkMock.Moq.Tests/EntityFrameworkMock.Moq.Tests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="7.0.1" />
     <PackageReference Include="Castle.Core" Version="4.3.1" />
     <PackageReference Include="EntityFramework" Version="6.2.0" />
     <PackageReference Include="Moq" Version="4.10.0" />


### PR DESCRIPTION
This piece of code fixes the problem when AutoMapper extension ProjectTo is being used.