### PR TITLE
Updated package references to latest versions

### DIFF
--- a/src/EntityFrameworkMock.Moq/EntityFrameworkMock.Moq.csproj
+++ b/src/EntityFrameworkMock.Moq/EntityFrameworkMock.Moq.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="4.3.1" />
+    <PackageReference Include="Castle.Core" Version="4.4.0" />
     <PackageReference Include="EntityFramework" Version="6.2.0" />
     <PackageReference Include="Moq" Version="4.10.0" />
   </ItemGroup>

--- a/src/EntityFrameworkMock.Moq/EntityFrameworkMock.Moq.csproj
+++ b/src/EntityFrameworkMock.Moq/EntityFrameworkMock.Moq.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.4.0" />
     <PackageReference Include="EntityFramework" Version="6.2.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
+    <PackageReference Include="Moq" Version="4.10.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EntityFrameworkMock.NSubstitute/DbContextMock.cs
+++ b/src/EntityFrameworkMock.NSubstitute/DbContextMock.cs
@@ -40,7 +40,7 @@ namespace EntityFrameworkMock.NSubstitute
 
         private DbContextMock(IKeyFactoryBuilder keyFactoryBuilder, params object[] args)
         {
-            Object = Substitute.ForPartsOf<TDbContext>(args);
+            Object = Substitute.For<TDbContext>(args);
             _keyFactoryBuilder = keyFactoryBuilder ?? throw new ArgumentNullException(nameof(keyFactoryBuilder));
             Reset();
         }

--- a/src/EntityFrameworkMock.NSubstitute/EntityFrameworkMock.NSubstitute.csproj
+++ b/src/EntityFrameworkMock.NSubstitute/EntityFrameworkMock.NSubstitute.csproj
@@ -15,9 +15,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="4.3.1" />
+    <PackageReference Include="Castle.Core" Version="4.4.0" />
     <PackageReference Include="EntityFramework" Version="6.2.0" />
-    <PackageReference Include="NSubstitute" Version="3.1.0" />
+    <PackageReference Include="NSubstitute" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EntityFrameworkMock.NSubstitute/EntityFrameworkMock.NSubstitute.csproj
+++ b/src/EntityFrameworkMock.NSubstitute/EntityFrameworkMock.NSubstitute.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.4.0" />
     <PackageReference Include="EntityFramework" Version="6.2.0" />
-    <PackageReference Include="NSubstitute" Version="4.1.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/EntityFrameworkMock.Moq.Tests/EntityFrameworkMock.Moq.Tests.csproj
+++ b/tests/EntityFrameworkMock.Moq.Tests/EntityFrameworkMock.Moq.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="AutoMapper" Version="8.1.0" />
     <PackageReference Include="Castle.Core" Version="4.4.0" />
     <PackageReference Include="EntityFramework" Version="6.2.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
+    <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>

--- a/tests/EntityFrameworkMock.Moq.Tests/EntityFrameworkMock.Moq.Tests.csproj
+++ b/tests/EntityFrameworkMock.Moq.Tests/EntityFrameworkMock.Moq.Tests.csproj
@@ -5,12 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="7.0.1" />
-    <PackageReference Include="Castle.Core" Version="4.3.1" />
+    <PackageReference Include="AutoMapper" Version="8.1.0" />
+    <PackageReference Include="Castle.Core" Version="4.4.0" />
     <PackageReference Include="EntityFramework" Version="6.2.0" />
     <PackageReference Include="Moq" Version="4.10.0" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/EntityFrameworkMock.NSubstitute.Tests/DbContextMockTests.cs
+++ b/tests/EntityFrameworkMock.NSubstitute.Tests/DbContextMockTests.cs
@@ -96,7 +96,6 @@ namespace EntityFrameworkMock.NSubstitute.Tests
         public void DbContextMock_CreateDbSetMock_ShouldSetupMockForDbSetSelector()
         {
             var dbContextMock = new DbContextMock<TestDbContext>("abc");
-            Assert.That(dbContextMock.Object.Users, Is.Null);
             dbContextMock.CreateDbSetMock<User>(x => x.Users);
             Assert.That(dbContextMock.Object.Users, Is.Not.Null);
         }

--- a/tests/EntityFrameworkMock.NSubstitute.Tests/DbContextMockTests.cs
+++ b/tests/EntityFrameworkMock.NSubstitute.Tests/DbContextMockTests.cs
@@ -96,6 +96,7 @@ namespace EntityFrameworkMock.NSubstitute.Tests
         public void DbContextMock_CreateDbSetMock_ShouldSetupMockForDbSetSelector()
         {
             var dbContextMock = new DbContextMock<TestDbContext>("abc");
+            Assert.That(dbContextMock.Object.Users, Is.Null);
             dbContextMock.CreateDbSetMock<User>(x => x.Users);
             Assert.That(dbContextMock.Object.Users, Is.Not.Null);
         }

--- a/tests/EntityFrameworkMock.NSubstitute.Tests/EntityFrameworkMock.NSubstitute.Tests.csproj
+++ b/tests/EntityFrameworkMock.NSubstitute.Tests/EntityFrameworkMock.NSubstitute.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="AutoMapper" Version="8.1.0" />
     <PackageReference Include="Castle.Core" Version="4.4.0" />
     <PackageReference Include="EntityFramework" Version="6.2.0" />
-    <PackageReference Include="NSubstitute" Version="4.1.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>

--- a/tests/EntityFrameworkMock.NSubstitute.Tests/EntityFrameworkMock.NSubstitute.Tests.csproj
+++ b/tests/EntityFrameworkMock.NSubstitute.Tests/EntityFrameworkMock.NSubstitute.Tests.csproj
@@ -6,9 +6,9 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="7.0.1" />
-    <PackageReference Include="Castle.Core" Version="4.3.1" />
+    <PackageReference Include="Castle.Core" Version="4.4.0" />
     <PackageReference Include="EntityFramework" Version="6.2.0" />
-    <PackageReference Include="NSubstitute" Version="3.1.0" />
+    <PackageReference Include="NSubstitute" Version="4.1.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
   </ItemGroup>

--- a/tests/EntityFrameworkMock.NSubstitute.Tests/EntityFrameworkMock.NSubstitute.Tests.csproj
+++ b/tests/EntityFrameworkMock.NSubstitute.Tests/EntityFrameworkMock.NSubstitute.Tests.csproj
@@ -5,12 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="7.0.1" />
+    <PackageReference Include="AutoMapper" Version="8.1.0" />
     <PackageReference Include="Castle.Core" Version="4.4.0" />
     <PackageReference Include="EntityFramework" Version="6.2.0" />
     <PackageReference Include="NSubstitute" Version="4.1.0" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/EntityFrameworkMock.Shared.Tests/EntityFrameworkMock.Shared.Tests.csproj
+++ b/tests/EntityFrameworkMock.Shared.Tests/EntityFrameworkMock.Shared.Tests.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.5.0" />
+    <PackageReference Include="AutoFixture" Version="4.8.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>

--- a/tests/EntityFrameworkMock.Shared.Tests/EntityFrameworkMock.Shared.Tests.csproj
+++ b/tests/EntityFrameworkMock.Shared.Tests/EntityFrameworkMock.Shared.Tests.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.5.0" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
When using the library with newer version of NSubstitute I get package conflicts.
Probably due to some breaking changes since version `3.1.0`.