### PR TITLE
Implements multi targeting for the NuGet package

### DIFF
--- a/src/EntityFrameworkMock.Moq/EntityFrameworkMock.Moq.csproj
+++ b/src/EntityFrameworkMock.Moq/EntityFrameworkMock.Moq.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.1</TargetFrameworks>
     <Title>EntityFrameworkMock.Moq</Title>
     <Product>EntityFrameworkMock</Product>
     <Version>1.0.0.0</Version>
@@ -19,7 +19,7 @@
     <PackageReference Include="Moq" Version="[4.10.0, 5.0.0)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="EntityFramework" Version="[6.1.1, 7.0.0)" />
   </ItemGroup>
 

--- a/src/EntityFrameworkMock.Moq/EntityFrameworkMock.Moq.csproj
+++ b/src/EntityFrameworkMock.Moq/EntityFrameworkMock.Moq.csproj
@@ -12,7 +12,6 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>Easy Mock wrapper for mocking EF6 DbContext and DbSet using Moq</Description>
     <Copyright>Copyright 2017-2019 Wouter Huysentruit</Copyright>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EntityFrameworkMock.Moq/EntityFrameworkMock.Moq.csproj
+++ b/src/EntityFrameworkMock.Moq/EntityFrameworkMock.Moq.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net45;netstandard2.1</TargetFrameworks>
     <Title>EntityFrameworkMock.Moq</Title>
     <Product>EntityFrameworkMock</Product>
     <Version>1.0.0.0</Version>
@@ -12,16 +12,23 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>Easy Mock wrapper for mocking EF6 DbContext and DbSet using Moq</Description>
     <Copyright>Copyright 2017-2019 Wouter Huysentruit</Copyright>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="4.4.0" />
-    <PackageReference Include="EntityFramework" Version="6.2.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="Castle.Core" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Moq" Version="[4.10.0, 5.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+    <PackageReference Include="EntityFramework" Version="[6.1.1, 7.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="EntityFramework" Version="[6.3.0, 7.0.0)" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\EntityFrameworkMock.Shared\EntityFrameworkMock.Shared.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/EntityFrameworkMock.NSubstitute/EntityFrameworkMock.NSubstitute.csproj
+++ b/src/EntityFrameworkMock.NSubstitute/EntityFrameworkMock.NSubstitute.csproj
@@ -12,7 +12,6 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>Easy Mock wrapper for mocking EF6 DbContext and DbSet using NSubstitute</Description>
     <Copyright>Copyright 2017-2019 Wouter Huysentruit, Paul Michaels</Copyright>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EntityFrameworkMock.NSubstitute/EntityFrameworkMock.NSubstitute.csproj
+++ b/src/EntityFrameworkMock.NSubstitute/EntityFrameworkMock.NSubstitute.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net45;netstandard2.1</TargetFrameworks>
     <Title>EntityFrameworkMock.NSubstitute</Title>
     <Product>EntityFrameworkMock</Product>
     <Version>1.0.0.0</Version>
@@ -12,12 +12,20 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>Easy Mock wrapper for mocking EF6 DbContext and DbSet using NSubstitute</Description>
     <Copyright>Copyright 2017-2019 Wouter Huysentruit, Paul Michaels</Copyright>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="4.4.0" />
-    <PackageReference Include="EntityFramework" Version="6.2.0" />
-    <PackageReference Include="NSubstitute" Version="4.2.0" />
+    <PackageReference Include="Castle.Core" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="NSubstitute" Version="[4.0.0, 5.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+    <PackageReference Include="EntityFramework" Version="[6.1.1, 7.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="EntityFramework" Version="[6.3.0, 7.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EntityFrameworkMock.NSubstitute/EntityFrameworkMock.NSubstitute.csproj
+++ b/src/EntityFrameworkMock.NSubstitute/EntityFrameworkMock.NSubstitute.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.1</TargetFrameworks>
     <Title>EntityFrameworkMock.NSubstitute</Title>
     <Product>EntityFrameworkMock</Product>
     <Version>1.0.0.0</Version>
@@ -19,7 +19,7 @@
     <PackageReference Include="NSubstitute" Version="[4.0.0, 5.0.0)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="EntityFramework" Version="[6.1.1, 7.0.0)" />
   </ItemGroup>
 

--- a/src/EntityFrameworkMock.Shared/EntityFrameworkMock.Shared.csproj
+++ b/src/EntityFrameworkMock.Shared/EntityFrameworkMock.Shared.csproj
@@ -12,7 +12,6 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>Shared code for EntityFrameworkMock.Moq</Description>
     <Copyright>Copyright 2017-2019 Wouter Huysentruit</Copyright>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EntityFrameworkMock.Shared/EntityFrameworkMock.Shared.csproj
+++ b/src/EntityFrameworkMock.Shared/EntityFrameworkMock.Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.1</TargetFrameworks>
     <Title>EntityFrameworkMock.Shared</Title>
     <Product>EntityFrameworkMock</Product>
     <Version>1.0.0.0</Version>
@@ -18,7 +18,7 @@
     <PackageReference Include="System.ValueTuple" Version="[4.3.0, 5.0.0)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="EntityFramework" Version="[6.1.1, 7.0.0)" />
   </ItemGroup>
 

--- a/src/EntityFrameworkMock.Shared/EntityFrameworkMock.Shared.csproj
+++ b/src/EntityFrameworkMock.Shared/EntityFrameworkMock.Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net45;netstandard2.1</TargetFrameworks>
     <Title>EntityFrameworkMock.Shared</Title>
     <Product>EntityFrameworkMock</Product>
     <Version>1.0.0.0</Version>
@@ -12,10 +12,21 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>Shared code for EntityFrameworkMock.Moq</Description>
     <Copyright>Copyright 2017-2019 Wouter Huysentruit</Copyright>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EntityFramework" Version="6.2.0" />
+    <PackageReference Include="System.ValueTuple" Version="[4.3.0, 5.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+    <PackageReference Include="EntityFramework" Version="[6.1.1, 7.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="EntityFramework" Version="[6.3.0, 7.0.0)" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="[4.6.0, 5.0.0)" />
+    <PackageReference Include="System.Data.SqlClient" Version="[4.7.0, 5.0.0)" />
   </ItemGroup>
 
 </Project>

--- a/tests/EntityFrameworkMock.Moq.Tests/EntityFrameworkMock.Moq.Tests.csproj
+++ b/tests/EntityFrameworkMock.Moq.Tests/EntityFrameworkMock.Moq.Tests.csproj
@@ -1,16 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="[4.3.1, 5.0.0)" />
-    <PackageReference Include="Moq" Version="[4.10.0, 5.0.0)" />
     <PackageReference Include="AutoMapper" Version="8.1.0" />
+    <PackageReference Include="Castle.Core" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Moq" Version="[4.10.0, 5.0.0)" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="EntityFramework" Version="[6.1.1, 7.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <PackageReference Include="EntityFramework" Version="[6.3.0, 7.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/EntityFrameworkMock.Moq.Tests/EntityFrameworkMock.Moq.Tests.csproj
+++ b/tests/EntityFrameworkMock.Moq.Tests/EntityFrameworkMock.Moq.Tests.csproj
@@ -5,16 +5,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Castle.Core" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="Moq" Version="[4.10.0, 5.0.0)" />
     <PackageReference Include="AutoMapper" Version="8.1.0" />
-    <PackageReference Include="Castle.Core" Version="4.4.0" />
-    <PackageReference Include="EntityFramework" Version="6.2.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+    <PackageReference Include="EntityFramework" Version="[6.1.1, 7.0.0)" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\EntityFrameworkMock.Moq\EntityFrameworkMock.Moq.csproj" />
   </ItemGroup>
-  
 </Project>

--- a/tests/EntityFrameworkMock.Moq.Tests/packages.config
+++ b/tests/EntityFrameworkMock.Moq.Tests/packages.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Castle.Core" version="4.2.1" targetFramework="net462" />
-  <package id="EntityFramework" version="6.2.0" targetFramework="net462" />
-  <package id="Moq" version="4.7.145" targetFramework="net462" />
-  <package id="NUnit" version="3.9.0" targetFramework="net462" />
-</packages>

--- a/tests/EntityFrameworkMock.NSubstitute.Tests/EntityFrameworkMock.NSubstitute.Tests.csproj
+++ b/tests/EntityFrameworkMock.NSubstitute.Tests/EntityFrameworkMock.NSubstitute.Tests.csproj
@@ -1,16 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="8.1.0" />
     <PackageReference Include="Castle.Core" Version="[4.3.1, 5.0.0)" />
-    <PackageReference Include="EntityFramework" Version="[6.1.1, 7.0.0)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="NSubstitute" Version="[4.0.0, 5.0.0)" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PackageReference Include="EntityFramework" Version="[6.1.1, 7.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <PackageReference Include="EntityFramework" Version="[6.3.0, 7.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/EntityFrameworkMock.NSubstitute.Tests/EntityFrameworkMock.NSubstitute.Tests.csproj
+++ b/tests/EntityFrameworkMock.NSubstitute.Tests/EntityFrameworkMock.NSubstitute.Tests.csproj
@@ -6,11 +6,11 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="8.1.0" />
-    <PackageReference Include="Castle.Core" Version="4.4.0" />
-    <PackageReference Include="EntityFramework" Version="6.2.0" />
-    <PackageReference Include="NSubstitute" Version="4.2.0" />
+    <PackageReference Include="Castle.Core" Version="[4.3.1, 5.0.0)" />
+    <PackageReference Include="EntityFramework" Version="[6.1.1, 7.0.0)" />
+    <PackageReference Include="NSubstitute" Version="[4.0.0, 5.0.0)" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/EntityFrameworkMock.Shared.Tests/EntityFrameworkMock.Shared.Tests.csproj
+++ b/tests/EntityFrameworkMock.Shared.Tests/EntityFrameworkMock.Shared.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>

--- a/tests/EntityFrameworkMock.Shared.Tests/EntityFrameworkMock.Shared.Tests.csproj
+++ b/tests/EntityFrameworkMock.Shared.Tests/EntityFrameworkMock.Shared.Tests.csproj
@@ -9,9 +9,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.8.0" />
+    <PackageReference Include="AutoFixture" Version="4.11.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
Modifies the libraries dependencies to support a wider range of versions

- Lowers .NET Framework supported version from 4.7.2 to 4.5
- Adds support for .NET Standard 2.1 (the minimum .NET Standard version supported by Entity Framework 6 - 6.3.0)
- Lowers the minimum supported version of EF 6 from 6.2.0 to 6.1.1, for .NET Framework 4.5
- Lowers the minimum supported version of Moq from 4.10.1 to 4.10.0
- Lowers the minimum supported version of NSubstitute from 4.2.0 to 4.0.0
- Introduces multi-targeting unit test projects
- Fixes unit tests for `SqlExceptionCreator` due to difference in private fields names in Entity Framework 6.3.0