### PR TITLE
Fix return value of SaveChanges

### DIFF
--- a/src/EntityFrameworkMock.Shared/DbSetBackingStore.cs
+++ b/src/EntityFrameworkMock.Shared/DbSetBackingStore.cs
@@ -99,7 +99,7 @@ namespace EntityFrameworkMock
                 else if (change.IsRemove) RemoveEntity(change.Entity);
             }
 
-            return _changes.Count;
+            return changes.Count;
         }
 
         /// <summary>


### PR DESCRIPTION
Change the SaveChanges method to return the count of changes applied, instead of the already cleared list of upcoming changes.

A similar PR has already been made to the EF Core version here https://github.com/cup-of-tea-dot-be/entity-framework-core-mock/pull/48

Fixes issue #19 