### PR TITLE
Update EntityFrameworkMock.Moq.csproj

### DIFF
--- a/src/EntityFrameworkMock.Moq/EntityFrameworkMock.Moq.csproj
+++ b/src/EntityFrameworkMock.Moq/EntityFrameworkMock.Moq.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="[4.4.1, 5.0.0)" />
+    <PackageReference Include="Castle.Core" Version="[4.4.1, 6.0.0)" />
     <PackageReference Include="Moq" Version="[4.14.5, 5.0.0)" />
   </ItemGroup>
 

--- a/tests/EntityFrameworkMock.Moq.Tests/EntityFrameworkMock.Moq.Tests.csproj
+++ b/tests/EntityFrameworkMock.Moq.Tests/EntityFrameworkMock.Moq.Tests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="8.1.0" />
-    <PackageReference Include="Castle.Core" Version="[4.4.1, 5.0.0)" />
+    <PackageReference Include="Castle.Core" Version="[4.4.1, 6.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="Moq" Version="[4.14.5, 5.0.0)" />
     <PackageReference Include="NUnit" Version="3.12.0" />


### PR DESCRIPTION
Here is proposed fix for requiring to tight on version of Castle.Core

Recently I've discover that your library has a bug related to count on SaveChanges(). I've tried updating it but EntityFrameworkMock.Moq is requiring quite low version of Castle.Core. They already passed version 5 and other libraries use newer stuff as well.

Locally I've checked out your branch. Updated nuget of Castle.Core to newest version and run all the tests. Would appreciate this change if it's not something that you cannot change as it requires downgrading bunch of libraries and if tests pass then it seems that everything works fine.

![image](https://github.com/huysentruitw/entity-framework-mock/assets/1476651/5b15a5b0-ea0b-43ab-95fa-450e4676788a)
